### PR TITLE
Issue #10: Kernel Fusion using torch.jit

### DIFF
--- a/pipegoose/utils/activations.py
+++ b/pipegoose/utils/activations.py
@@ -1,0 +1,42 @@
+import torch
+from torch import Tensor
+from torch.nn import functional as F
+
+""" 
+From Issue Kernel Fusion using torch.jit #10 - https://github.com/xrsrke/pipegoose/issues/10
+
+Fuse some popular functions and automatically replace modules in an existing 
+🤗 transformers model with their corresponding fusion module
+
+Some decisions that need to be made:
+    1. Where should this be implemented?
+    2. How should the automatic replacement be done?  
+"""
+
+class _FusedBiasGelu(torch.autograd.Function):
+    """Fused gelu + bias addition function."""
+
+    @staticmethod
+    def forward(ctx, input):
+        pass
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        pass
+
+class _FusedBiasDropout(torch.autograd.Function):
+    """Fused bias + dropout function."""
+
+    @staticmethod
+    def forward(ctx, input):
+        pass
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        pass
+
+def fused_bias_gelu(x):
+    pass
+
+def fused_bias_dropout():
+    pass


### PR DESCRIPTION
From the issue description:

_Fuse some popular functions and automatically replace modules in an existing 🤗 transformers model with their corresponding fusion module_

TODOs

- [ ]  Decide on location to implement fused functions

- [ ]  Decide on a way to automatically replace modules on import, i.e. whenever someone imports a 🤗transformer model, its activations are replaced with the fused implementations. @xrsrke I'm not sure I understand this part properly?
- [ ]  Fuse bias addition and GeLU [[link]](https://github.com/EleutherAI/oslo/blob/d7c4e32e766a99cc9d56533bc090570360dc8b2a/oslo/torch/nn/modules/functional.py#L287)
- [ ]  Fuse bias addition and dropout [[link]](https://github.com/EleutherAI/oslo/blob/d7c4e32e766a99cc9d56533bc090570360dc8b2a/oslo/torch/nn/modules/functional.py#L296C5-L296C23)

Reading (could be ignored)

OSLO’s kernel fusion [[[link]](https://github.com/tunib-ai/oslo/blob/88dcca0441a605b462bf825cb0104bc692f14c57/oslo/fused_kernels_utils.py#L259)](https://github.com/tunib-ai/oslo/blob/88dcca0441a605b462bf825cb0104bc692f14c57/oslo/fused_kernels_utils.py#L259)
GPT-NeoX’s kernel fusion [[[link]](https://github.com/EleutherAI/gpt-neox/blob/b02d98932f95fe0500c28698b38acb175e92e980/megatron/model/activations.py#L27)](https://github.com/EleutherAI/gpt-neox/blob/b02d98932f95fe0500c28698b38acb175e92e980/megatron/model/activations.py#L27)