### PR TITLE
[Bug Fix] Balance transformer blocks across shards

### DIFF
--- a/pipegoose/nn/pipeline_parallel/partitioner.py
+++ b/pipegoose/nn/pipeline_parallel/partitioner.py
@@ -93,11 +93,6 @@ class UniformPartitioner(BasePartitioner):
                 current_param_count = param_count.get(node.name, 0)
                 new_transformer_block_id = self._get_transformer_block_id(node.name)
                 # Check if a new transformer block has started
-                print(
-                    new_transformer_block_id,
-                    current_transformer_block,
-                    new_transformer_block_id != current_transformer_block,
-                )
                 if new_transformer_block_id != current_transformer_block:
                     # End the previous block and start a new one
                     current_transformer_block = new_transformer_block_id
@@ -132,7 +127,6 @@ class UniformPartitioner(BasePartitioner):
                             output_from_shard.setdefault(idx, dict())[arg.name] = None
 
             node_name_to_shard_id[node.name] = shard_id
-            print("node: ", node.name, shard_id)
         return node_name_to_shard_id, output_from_shard
 
     def split(self, input_names: List[str]) -> List[nn.Module]:

--- a/tests/nn/pipeline_parallel/test_partitioner.py
+++ b/tests/nn/pipeline_parallel/test_partitioner.py
@@ -87,13 +87,13 @@ def run_model_partitioner(
     assert torch.allclose(gt_logits, partitioned_model_result), "Results are not close"
 
 
-@pytest.mark.parametrize("pipeline_parallel_size", [5])
+@pytest.mark.parametrize("pipeline_parallel_size", [2, 3, 4, 5, 6])
 @pytest.mark.parametrize(
     "model_retrieval_func",
     [
-        # get_gpt2_and_tokenizer,
+        get_gpt2_and_tokenizer,
         get_bloom_and_tokenizer_with_6_layers,
-        # get_bloom_560m_and_tokenizer,
+        get_bloom_560m_and_tokenizer,
     ],
 )
 def test_naive_partitioning(pipeline_parallel_size, model_retrieval_func):

--- a/tests/nn/pipeline_parallel/test_partitioner.py
+++ b/tests/nn/pipeline_parallel/test_partitioner.py
@@ -62,7 +62,6 @@ def run_model_partitioner(
         len(partitioned_model) == pipeline_parallel_size
     ), f"Received model with {len(partitioned_model)} instead of {pipeline_parallel_size}"
 
-    """
     print("start")
     for p in partitioned_model:
         print("==================")
@@ -71,9 +70,6 @@ def run_model_partitioner(
             print(v)
         print("==================")
     print("end")
-
-
-    """
 
     inputs = tokenizer(batch_sentences, padding=True, return_tensors="pt")
 
@@ -95,7 +91,9 @@ def run_model_partitioner(
 @pytest.mark.parametrize(
     "model_retrieval_func",
     [
-        get_bloom_560m_and_tokenizer,
+        # get_gpt2_and_tokenizer,
+        get_bloom_and_tokenizer_with_6_layers,
+        # get_bloom_560m_and_tokenizer,
     ],
 )
 def test_naive_partitioning(pipeline_parallel_size, model_retrieval_func):


### PR DESCRIPTION
As we were discussing, the current implementation works like this:

1. It first gives an equal number of parameters to each shard.
2. If a transformer block is going to be split across diferent shards, prevent it, and make the current transformer block part of the current shard.

This way, we can guarantee that each shard/partition will get an equal amount of transformer blocks.

But there is an edge case, where if we specify that we want 5 shards and we have 6 transformer blocks in the model, In that case:

Shard 1 to 3 get 2 transformer blocks each, shard 4 gets the final layers and shard 5 doesn't get nothing.

To prevent this, if balance is not really important, we could shard based on transformer blocks, so if 5 shards were specified, shard 1 would get 2 transformer blocks and shard 2 to 5 would get 1 transformer block.

