### PR TITLE
Add expert loss function

### DIFF
--- a/pipegoose/nn/expert_parallel/__init__.py
+++ b/pipegoose/nn/expert_parallel/__init__.py
@@ -1,3 +1,4 @@
+from pipegoose.nn.expert_parallel.expert_context import ExpertContext
 from pipegoose.nn.expert_parallel.expert_parallel import ExpertParallel
 from pipegoose.nn.expert_parallel.loss import ExpertLoss
 from pipegoose.nn.expert_parallel.routers import Top1Router, Top2Router, SwitchNoisePolicy

--- a/pipegoose/nn/expert_parallel/expert_context.py
+++ b/pipegoose/nn/expert_parallel/expert_context.py
@@ -1,0 +1,23 @@
+from typing import List
+
+from torchtyping import TensorType
+
+
+class ExpertContext:
+    def __init__(self):
+        self.aux_loss = []
+        self.z_loss = []
+
+    def push_aux_loss(self, aux_loss: TensorType):
+        self.aux_loss.append(aux_loss)
+
+    def pop_all_aux_loss(self) -> List[TensorType]:
+        aux_loss, self.aux_loss = self.aux_loss, []
+        return aux_loss
+
+    def push_z_loss(self, z_loss: TensorType):
+        self.z_loss.append(z_loss)
+
+    def pop_all_z_loss(self) -> List[TensorType]:
+        z_loss, self.z_loss = self.z_loss, []
+        return z_loss

--- a/pipegoose/nn/expert_parallel/expert_parallel.py
+++ b/pipegoose/nn/expert_parallel/expert_parallel.py
@@ -8,6 +8,7 @@ from pipegoose.distributed.parallel_context import ParallelContext
 from pipegoose.distributed.parallel_mode import ParallelMode
 from pipegoose.nn.expert_parallel.layers import ExpertLayer
 from pipegoose.nn.parallel import Parallel
+from pipegoose.nn.expert_parallel.expert_context import ExpertContext
 
 
 class ExpertParallel(Parallel):
@@ -28,6 +29,7 @@ class ExpertParallel(Parallel):
         # noise_poligy: Union[str, Callable],
         enable_tensor_parallelism: bool = False,
         parallel_context: ParallelContext = None,
+        expert_context: ExpertContext = None
     ):
         tensor_parallel_size = parallel_context.get_world_size(ParallelMode.TENSOR)
         assert parallel_context is not None, "parallel_context must be provided"
@@ -49,6 +51,7 @@ class ExpertParallel(Parallel):
         # self.noise_policy = noise_poligy
         self.enable_tensor_parallelism = enable_tensor_parallelism
         self.parallel_context = parallel_context
+        self.expert_context = expert_context
 
     @torch.no_grad()
     def parallelize(self) -> nn.Module:
@@ -65,6 +68,7 @@ class ExpertParallel(Parallel):
                         self.router,
                         self.enable_tensor_parallelism,
                         self.parallel_context,
+                        self.expert_context
                     )
                     getattr(self.module, "transformer").h[layer_idx].mlp = expert_layer
 

--- a/pipegoose/nn/expert_parallel/loss.py
+++ b/pipegoose/nn/expert_parallel/loss.py
@@ -1,12 +1,22 @@
 from typing import Callable
+from torchtyping import TensorType
 
-import torch
+from pipegoose.nn.expert_parallel.expert_context import ExpertContext
 
 
 class ExpertLoss:
-    def __init__(self, loss: Callable, aux_weight: float):
-        self.loss = loss
+    def __init__(self, loss_func: Callable, aux_weight: float, z_weight: float):
+        self.loss_func = loss_func
         self.aux_weight = aux_weight
+        self.z_weight = z_weight
+        self._expert_context = ExpertContext()
 
-    def __call__(self) -> torch.Tensor:
-        pass
+    @property
+    def expert_context(self) -> ExpertContext:
+        return self._expert_context
+
+    def __call__(self, *args, **kwargs) -> TensorType:
+        loss = self.loss_func(*args, **kwargs)
+        loss += self.aux_weight * sum(self._expert_context.pop_all_aux_loss())
+        loss += self.z_weight * sum(self._expert_context.pop_all_z_loss())
+        return loss

--- a/tests/nn/expert_parallel/test_expert_context.py
+++ b/tests/nn/expert_parallel/test_expert_context.py
@@ -1,0 +1,17 @@
+from pipegoose.nn.expert_parallel import ExpertContext
+
+
+def test_expert_context():
+    expert_context = ExpertContext()
+
+    expert_context.push_aux_loss(1.01)
+    expert_context.push_z_loss(2.01)
+
+    expert_context.push_aux_loss(1.02)
+    expert_context.push_z_loss(2.02)
+
+    assert expert_context.pop_all_aux_loss() == [1.01, 1.02]
+    assert expert_context.pop_all_aux_loss() == []
+    
+    assert expert_context.pop_all_z_loss() == [2.01, 2.02]
+    assert expert_context.pop_all_z_loss() == []

--- a/tests/nn/expert_parallel/test_expert_loss.py
+++ b/tests/nn/expert_parallel/test_expert_loss.py
@@ -1,24 +1,34 @@
+import torch
 from torch import nn
+import torch.nn.functional as F
 
 from pipegoose.nn.expert_parallel import ExpertLoss
 
 
 def test_expert_loss():
-    loss_func = nn.CrossEntropyLoss()
+    torch.manual_seed(42)
+    logits = torch.randn((10, 5))
+    gt = torch.randn((10, 5))
 
-    expert_loss = ExpertLoss(loss_func, aux_weight=0.1)
+    loss_func = nn.MSELoss()
+
+    expert_loss = ExpertLoss(loss_func, aux_weight=0.1, z_weight=0.2)
+    expert_context = expert_loss.expert_context
 
     assert expert_loss.aux_weight == 0.1
+    assert expert_loss.z_weight == 0.2
     assert expert_loss.loss_func == loss_func
 
-    ExpertLoss.add_aux_loss(1.01)
-    ExpertLoss.add_z_loss(2.01)
+    expert_context.push_aux_loss(1.01)
+    expert_context.push_z_loss(2.01)
 
-    assert expert_loss.get_aux_loss() == [1.01]
-    assert expert_loss.get_z_loss() == [2.01]
+    expert_context.push_aux_loss(1.02)
+    expert_context.push_z_loss(2.02)
 
-    ExpertLoss.add_aux_loss(1.02)
-    ExpertLoss.add_z_loss(2.02)
+    expected_loss = F.mse_loss(logits, gt) + 0.1 * (1.01 + 1.02) + 0.2 * (2.01 + 2.02)
+    loss = expert_loss(logits, gt)
 
-    assert expert_loss.get_aux_loss() == [1.01, 1.02]
-    assert expert_loss.get_z_loss() == [2.01, 2.02]
+    assert torch.allclose(loss, expected_loss)
+
+    assert expert_context.aux_loss == []
+    assert expert_context.z_loss == []


### PR DESCRIPTION
The following is a sketch for using `ExpertLoss`:

```
loss_func = ExpertLoss(CrossEntropyLoss(), aux_weight=0.1, z_weight=0.1)

parallel_context = init_parallel_context(...)
 model = ExpertParallel(
      model,
      NUM_EXPERTS,
      mapping=mapping,
      router=router,
      parallel_context=parallel_context,
      expert_context=loss_func.expert_context   # PASS EXPERT CONTEXT HERE
  ).parallelize()
  optim = Adam(model.parameters(), lr=1e-3)


outputs = model(**kwargs["input"])

loss = loss_func(outputs.logits, labels)

optim.zero_grad()
loss.backward()
optim.step()
```

@xrsrke Let me know what you think about this design.